### PR TITLE
`prep_slc_isce`: fix bug for stripmapStack products

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ conda activate miaplpy-env
 python -m pip install .
 ```
 
-#### 4. Install [SNAPHU](https://web.stanford.edu/group/radar/softwareandlinks/sw/snaphu/) 
+#### 4. Install [SNAPHU](https://web.stanford.edu/group/radar/softwareandlinks/sw/snaphu/)
 ```
 export TOOLS_DIR=~/tools
 cd ~/tools;
@@ -36,5 +36,6 @@ cd snaphu/src; make
 export PATH=${TOOLS_DIR}/snaphu/bin:${PATH}
 ```
 
-### Notes
-Please read notes on [PyAPS](https://github.com/insarlab/PyAPS) from [GitHub/MintPy](https://github.com/insarlab/MintPy/blob/main/docs/installation.md) 
+#### Notes
+
+Please read notes on the account setup for [PyAPS](https://github.com/insarlab/pyaps#2-account-setup-for-era5).

--- a/src/miaplpy/prep_slc_isce.py
+++ b/src/miaplpy/prep_slc_isce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 ############################################################
-# Program is part of MiaplPy                                #
-# Author:  Sara Mirzaee, Zhang Yunjun, Heresh Fattahi                    #
+# Program is part of MiaplPy                               #
+# Author:  Sara Mirzaee, Zhang Yunjun, Heresh Fattahi      #
 ############################################################
 # Modified from prep4timeseries.py in ISCE-2.2.0/contrib/stack/topsStack
 
@@ -34,7 +34,7 @@ enablePrint()
 
 EXAMPLE = """example:
   prep_slc_isce.py -s ./merged/SLC -m ./reference/IW1.xml -b ./baselines -g ./merged/geom_reference  #for topsStack
-  prep_slc_isce.py -s ./merged/SLC -m .merged/SLC/20190510/referenceShelve/data.dat -b ./baselines -g ./merged/geom_reference  #for stripmapStack
+  prep_slc_isce.py -s ./merged/SLC -m ./merged/SLC/20190510/referenceShelve/data.dat -b ./baselines -g ./merged/geom_reference  #for stripmapStack
   """
 
 GEOMETRY_PREFIXS = ['hgt', 'lat', 'lon', 'los', 'shadowMask', 'waterMask', 'incLocal']
@@ -294,14 +294,14 @@ def prepare_geometry(geom_dir, geom_files=[], metadata=dict(), processor='tops',
 
 def prepare_stack(inputDir, filePattern, processor='tops', metadata=dict(), baseline_dict=dict(), update_mode=True):
 
-    if not os.path.exists(glob.glob(os.path.join(os.path.abspath(inputDir), '*', filePattern + '.xml'))[0]):
+    if len(glob.glob(os.path.join(os.path.abspath(inputDir), '*', filePattern))) == 0:
         filePattern = filePattern.split('.full')[0]
     print('preparing RSC file for ', filePattern)
 
     if processor in ['tops', 'stripmap']:
-        isce_files = sorted(glob.glob(os.path.join(os.path.abspath(inputDir), '*', filePattern + '.xml')))
+        isce_files = sorted(glob.glob(os.path.join(os.path.abspath(inputDir), '*', filePattern)))
     elif processor == 'alosStack':
-        isce_files = sorted(glob.glob(os.path.join(os.path.abspath(inputDir), filePattern + '.xml')))    # not sure
+        isce_files = sorted(glob.glob(os.path.join(os.path.abspath(inputDir), filePattern)))    # not sure
     else:
         raise ValueError('Un-recognized ISCE stack processor: {}'.format(processor))
 
@@ -312,11 +312,11 @@ def prepare_stack(inputDir, filePattern, processor='tops', metadata=dict(), base
     num_file = len(isce_files)
     slc_dates = np.sort(os.listdir(inputDir))
     prog_bar = ptime.progressBar(maxValue=num_file)
-    for i in range(num_file):
+    for i, isce_file in enumerate(isce_files):
         # prepare metadata for current file
-        isce_file = isce_files[i].split('.xml')[0]
         dates = [slc_dates[0], os.path.basename(os.path.dirname(isce_file))]
-        slc_metadata = read_attribute(isce_file, metafile_ext='.xml')
+        # use .vrt instead of .xml, because the latter does not exist in stripmapStack products
+        slc_metadata = read_attribute(isce_file, metafile_ext='.vrt')
         slc_metadata.update(metadata)
         slc_metadata = add_slc_metadata(slc_metadata, dates, baseline_dict)
 


### PR DESCRIPTION
This PR adds the following changes in `prep_slc_isce.prepare_stack()`:

1. fix the bug while check `.slc.full` (from topsStack) or `.slc` (from stripmapStack) file pattern

2. use the SLC file directly, instead of the XML file, while searching for `isce_files`, for simplicity

3. read metadata from VRT file, instead of XML file, to be more robust, as the XML file does not exist for stripmapStack, as shown below for the SLC file structure:

SLC stack from topsStack:
+ 20240101.slc.full
+ 20240101.slc.full.xml
+ 20240101.slc.full.vrt

SLC stack from stripmapStack
+ 20240101.slc
+ 20240101.slc.vrt

4. fix a typo in the EXAMPLE usage

## Summary by Sourcery

Fix the bug in the SLC file pattern check for stripmapStack products, simplify the file search by using SLC files directly, and enhance robustness by reading metadata from VRT files. Correct a typo in the example usage and update installation documentation with PyAPS account setup notes.

Bug Fixes:
- Fix the bug in checking the SLC file pattern for stripmapStack products.

Enhancements:
- Use the SLC file directly instead of the XML file when searching for isce_files for simplicity.
- Read metadata from the VRT file instead of the XML file to improve robustness, as the XML file does not exist for stripmapStack.

Documentation:
- Correct a typo in the example usage of the prep_slc_isce script.
- Update the installation documentation to include notes on the account setup for PyAPS.