### PR TITLE
`tcoh_view`: fix `mintpy.utils.arg_utils` import

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![Language](https://img.shields.io/badge/python-3.6%2B-blue.svg)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-GPLv3-yellow.svg)](https://github.com/insarlab/MiaplPy/blob/main/LICENSE)
-[![Version](https://img.shields.io/badge/version-v0.2.0-yellowgreen.svg)](https://github.com/insarlab/MiaplPy/releases)
+[![Version](https://img.shields.io/github/v/release/insarlab/MiaplPy?color=yellowgreen&label=version)](https://github.com/insarlab/MiaplPy/releases)
 
 
 ## MiaplPy ##

--- a/src/miaplpy/prep_slc_isce.py
+++ b/src/miaplpy/prep_slc_isce.py
@@ -107,7 +107,7 @@ def extract_isce_metadata(meta_file, geom_dir=None, rsc_file=None, update_mode=T
                 rsc_file  : str, output file name of ROIPAC format rsc file
     Returns:    metadata  : dict
     """
-    
+
     if not rsc_file:
         rsc_file = os.path.join(os.path.dirname(meta_file), 'data.rsc')
 
@@ -379,7 +379,7 @@ def main(iargs=None):
         baseline_dict = isce_utils.read_baseline_timeseries(inps.baselineDir,
                                                             processor=inps.processor)
 
-    ''' 
+    '''
     # read baseline info
     baseline_dict = {}
     if inps.baselineDir:

--- a/src/miaplpy/tcoh_view.py
+++ b/src/miaplpy/tcoh_view.py
@@ -12,7 +12,7 @@ from matplotlib import pyplot as plt
 from mintpy.cli import timeseries2velocity as ts2vel
 import mintpy.cli.tsview as tsview
 from miaplpy.objects.invert_pixel import ks_lut_cy, get_shp_row_col_c, custom_cmap, gam_pta
-from mintpy.utils import arg_group, ptime, time_func, readfile, plot as pp
+from mintpy.utils import arg_utils, ptime, time_func, readfile, plot as pp
 from miaplpy.objects.slcStack import slcStack
 import miaplpy.lib.utils as iut
 
@@ -64,7 +64,7 @@ def create_parser():
                              '[!-- Preliminary feature alert! --!]\n'
                              '[!-- This feature is NOT throughly checked. Read the code before use. Interpret at your own risk! --!]')
 
-    parser = arg_group.add_timefunc_argument(parser)
+    parser = arg_utils.add_timefunc_argument(parser)
 
     # pixel of interest
     pixel = parser.add_argument_group('Pixel Input')
@@ -77,16 +77,16 @@ def create_parser():
     pixel.add_argument('--ew', '--edgewidth', dest='edge_width', type=float, default=1.0, help='Edge width for the error bar (default: %(default)s)')
 
     # other groups
-    parser = arg_group.add_data_disp_argument(parser)
-    parser = arg_group.add_dem_argument(parser)
-    parser = arg_group.add_figure_argument(parser)
-    parser = arg_group.add_gps_argument(parser)
-    parser = arg_group.add_mask_argument(parser)
-    parser = arg_group.add_map_argument(parser)
-    parser = arg_group.add_memory_argument(parser)
-    parser = arg_group.add_reference_argument(parser)
-    parser = arg_group.add_save_argument(parser)
-    parser = arg_group.add_subset_argument(parser)
+    parser = arg_utils.add_data_disp_argument(parser)
+    parser = arg_utils.add_dem_argument(parser)
+    parser = arg_utils.add_figure_argument(parser)
+    parser = arg_utils.add_gps_argument(parser)
+    parser = arg_utils.add_mask_argument(parser)
+    parser = arg_utils.add_map_argument(parser)
+    parser = arg_utils.add_memory_argument(parser)
+    parser = arg_utils.add_reference_argument(parser)
+    parser = arg_utils.add_save_argument(parser)
+    parser = arg_utils.add_subset_argument(parser)
 
     return parser
 


### PR DESCRIPTION
This PR does the following: 
+ fixes the `mintpy.utils.arg_utils` import error (#100) in `tcoh.view.py`
+ use the dynamic version badge in `README.md`, instead of manually updating it for each release