### PR TITLE
fix conflicting use of datetime.datetime and datetime.timedelta 

### DIFF
--- a/src/miaplpy/find_short_baselines.py
+++ b/src/miaplpy/find_short_baselines.py
@@ -5,7 +5,7 @@ import os
 import glob
 import numpy as np
 import argparse
-from datetime import datetime
+from datetime import datetime, timedelta
 from scipy.spatial import Delaunay
 
 def cmd_line_parse(iargs=None):
@@ -257,15 +257,15 @@ def find_mini_stacks(date_list, baseline_dir, month=6):
     return pairs
 
 def find_one_year_interferograms(date_list):
-    dates = np.array([datetime.datetime.strptime(date, '%Y%m%d') for date in date_list])
+    dates = np.array([datetime.strptime(date, '%Y%m%d') for date in date_list])
 
     ifg_ind = []
     for i, date in enumerate(dates):
-        range_1 = date + datetime.timedelta(days=365) - datetime.timedelta(days=5)
-        range_2 = date + datetime.timedelta(days=365) + datetime.timedelta(days=5)
+        range_1 = date + timedelta(days=365) - timedelta(days=5)
+        range_2 = date + timedelta(days=365) + timedelta(days=5)
         index = np.where((dates >= range_1) * (dates <= range_2))[0]
         if len(index) >= 1:
-            date_diff = list(dates[index] - (date + datetime.timedelta(days=365)))
+            date_diff = list(dates[index] - (date + timedelta(days=365)))
             ind = date_diff.index(np.nanmin(date_diff))
             ind_date = index[ind]
             date2 = date_list[ind_date]


### PR DESCRIPTION
Fix:     
self.ifgram_dir, self.pairs = self.get_interferogram_pairs()
  File "/home/mambauser/tools/MiaplPy/src/miaplpy/miaplpyApp.py", line 436, in get_interferogram_pairs
    one_years = fb.find_one_year_interferograms(self.date_list)
  File "/opt/conda/lib/python3.10/site-packages/miaplpy/find_short_baselines.py", line 260, in find_one_year_interferograms
    dates = np.array([datetime.datetime.strptime(date, '%Y%m%d') for date in date_list])
  File "/opt/conda/lib/python3.10/site-packages/miaplpy/find_short_baselines.py", line 260, in <listcomp>
    dates = np.array([datetime.datetime.strptime(date, '%Y%m%d') for date in date_list])
AttributeError: type object 'datetime.datetime' has no attribute 'datetime

The file has an import of import datetime.datetime and in function 'find_shortbaseline.py' it assumed an import of only the package datetime, hence the use of datetime.datetime.strptime returned an AttributeError. The same counts for datetime.timedelta (because the imported datetime.datetime has no attribute timedelta).

## Summary by Sourcery

Bug Fixes:
- Fixes an AttributeError caused by the incorrect usage of `datetime.datetime` and `datetime.timedelta` within the `find_short_baselines.py` module. The code was assuming an import of only the `datetime` package, but was referencing `datetime.datetime.strptime` which caused the error.