### PR TITLE
fix slcStack `UNIT` metadata

### DIFF
--- a/src/miaplpy/objects/crop_geo.py
+++ b/src/miaplpy/objects/crop_geo.py
@@ -35,7 +35,7 @@ CPX_ZERO = np.complex64(0.0)
 dataType = np.complex64
 
 slcDatasetNames = ['slc']
-DSET_UNIT_DICT['slc'] = 'i'
+DSET_UNIT_DICT['slc'] = '1'
 gdal.SetCacheMax(2**30)
 
 

--- a/src/miaplpy/objects/slcStack.py
+++ b/src/miaplpy/objects/slcStack.py
@@ -34,7 +34,7 @@ CPX_ZERO = np.complex64(0.0)
 dataType = np.complex64
 
 slcDatasetNames = ['slc']
-DSET_UNIT_DICT['slc'] = 'i'
+DSET_UNIT_DICT['slc'] = '1'
 gdal.SetCacheMax(2**30)
 ########################################################################################
 


### PR DESCRIPTION
This PR fixes the slcStack file metadata `UNIT` value from `i` to `1`.

## Summary by Sourcery

Bug Fixes:
- Correct the `UNIT` metadata value for SLC datasets in DSET_UNIT_DICT from `'i'` to `'1'`.